### PR TITLE
No ssh key in install mode

### DIFF
--- a/static/usr/bin/core-sshd-host-keygen
+++ b/static/usr/bin/core-sshd-host-keygen
@@ -63,4 +63,7 @@ create_keys() {
 		"$hostkeys" /etc/ssh/ssh_host_ed25519_key -t ed25519
 }
 
-create_keys
+# create keys only if we are in run mode, there is no use to create keys in install mode
+if ! grep -q "snapd_recovery_mode=install" /proc/cmdline; then
+	create_keys
+fi


### PR DESCRIPTION
Skip ssh key generation at install mode run

Not a big delay on fast devices, but saves some seconds on slow devices
